### PR TITLE
Allow @tables port to be configurable for sandbox 

### DIFF
--- a/lib/architect/tables.rb
+++ b/lib/architect/tables.rb
@@ -11,7 +11,7 @@ module Arc
     #
     def self.table(tablename:)
       ddb = if ENV['NODE_ENV'] == 'testing' 
-              Aws::DynamoDB::Resource.new :endpoint=> 'http://localhost:5000'
+              Aws::DynamoDB::Resource.new endpoint: "http://localhost:#{Arc::Tables.port}"
             else
               Aws::DynamoDB::Resource.new
             end
@@ -24,13 +24,17 @@ module Arc
     def self.name(tablename:)
       if ENV['NODE_ENV'] == 'testing'
         tmp = "staging-#{tablename}"
-        db = Aws::DynamoDB::Resource.new :endpoint=> 'http://localhost:5000'
+        db = Aws::DynamoDB::Resource.new endpoint: "http://localhost:#{Arc::Tables.port}"
         tbl = db.tables().detect {|e| e.name.include?(tmp)}
         tbl.name
       else
         arc = Arc.reflect
         arc['tables'][tablename]
       end
+    end
+
+    def self.port
+      ENV.fetch('ARC_TABLES_PORT') { 5555 }
     end
   end
 end


### PR DESCRIPTION
This PR allows for the following:
* Allows the @tables port to be configured in sandbox using the ARC_TABLES_PORT environment variable as mentioned in the **Local Database** section of https://arc.codes/docs/en/reference/cli/sandbox. 
* Updates the sandbox default tables port to 5555, which is the [new default tables port for sandbox](https://github.com/architect/sandbox/blob/main/src/sandbox/ports.js#L47)

